### PR TITLE
Fixed navbar to left side and adjusted height values to properly size it

### DIFF
--- a/src/components/Navbar/Navbar.scss
+++ b/src/components/Navbar/Navbar.scss
@@ -2,7 +2,8 @@
 
 .custom-navbar {
   background-color: $gray-800;
-  height: 100vh;
+  height: 100%;
+  position: fixed;
 }
 
 .brand-icon {
@@ -38,7 +39,7 @@ svg.teal-600 {
 }
 
 .custom-nav-items {
-  height: calc(100vh - 126px);
+  height: calc(100% - 126px);
 
   .topic-item {
     height: 45px;


### PR DESCRIPTION
Set `position:fixed` on navbar div.

Adjusted height values in navbar and nav-items divs to use `100%` instead of `100vh`.  Using `100vh` was causing issues on some mobile emulations where the height wasn't calculated properly.

Closes #40.